### PR TITLE
Memory and static analyzer fixes

### DIFF
--- a/HTMLNode.m
+++ b/HTMLNode.m
@@ -245,6 +245,7 @@ void childrenOfTag(const xmlChar * tagName, xmlNode * node, NSMutableArray * arr
 
 - (NSDictionary *)attributes
 {
+    if (xmlNode_ == NULL) return nil;
     if (self.isDocumentNode) return nil;
     
     NSMutableDictionary *result = [NSMutableDictionary dictionary];
@@ -1024,6 +1025,7 @@ void childrenOfTag(const xmlChar * tagName, xmlNode * node, NSMutableArray * arr
 // includes type, name , number of children, attributes and the first 80 characters of raw content
 - (NSString *)description
 {
+    if (xmlNode_ == NULL) return nil;
     return [NSString stringWithFormat:@"type: %d - name: %@ - number of children: %lu\nattributes: %@\nHTML: %@",
             self.elementType,  self.tagName, (long)self.childCount, self.attributes, self.HTMLString];
 }


### PR DESCRIPTION
I have a few fixes for HTMLDocument for your consideration.

The changes to HTMLDocument.m fix two problems:
- convertStringEncoding could return NULL if CFStringGetCStringPtr returned NULL
- 2 initWithData: methods assumed the data was null-terminated

I discovered both of these problems using the "Enable Scribble" and "Enable Guard Edges" debugger settings while tracking down bugs in my own code.

I also added a couple of NULL checks to HTMLNode.m just to make the clang static analyzer happy.
